### PR TITLE
Migrate Bookshelf to Google Sheets Backend 

### DIFF
--- a/bookshelf.html
+++ b/bookshelf.html
@@ -23,196 +23,21 @@
   <!-- Icon -->
   <link rel="icon" href="img/bregan_profile.jpeg">
 
+  <!-- JQuery -->
+  <script src="vendor/jquery/jquery.min.js"></script>
+
+
 </head>
 <body>
 	<div class="container-fluid p-0">
 
 	      <section class="resume-section p-3 p-lg-5 d-flex align-items-center" id="bookshelf">
-	        <div class="w-100">
+	        <div class="w-100" id='bookshelfContent'>
 	          <h1 class="mb-0">Bookshelf</h1>
-	          <div class="subheading mb-5">A list of what I've been reading recently, approximately chronologically ordered. Particular favourites in <span class="text-success">green</span>.</div>
+	          <div class="subheading mb-5">A list of what I've been reading. Particular favourites in <span class="text-success">green</span>.</div>
 
-            <h2 class="mb-5">2020</h2>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/6748.A_Supposedly_Fun_Thing_I_ll_Never_Do_Again" target="_blank">A Supposedly Fun Thing I'll Never Do Again</a></h3>
-              <div class="subheading mb-3">David Foster Wallace</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/41552709-the-uninhabitable-earth" target="_blank">The Uninhabitable Earth</a></h3>
-              <div class="subheading mb-3">David Wallace-Wells</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/34128219-la-belle-sauvage" target="_blank" class="text-success">La Belle Sauvage</a></h3>
-              <div class="subheading mb-3">Philip Pullman</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/51903501-boulevard-wren-and-other-stories" target="_blank">Boulevard Wren</a></h3>
-              <div class="subheading mb-3">Blindboy Boatclub</div>
-
-
-	          <h2 class="mb-5">2019</h2>
-
-	            <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/42975172-the-testaments" target="_blank">The Testaments</a></h3>
-              <div class="subheading mb-3">Margaret Atwood</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/327.Why_Zebras_Don_t_Get_Ulcers" target="_blank">Why Zebras Don't Get Ulcers</a></h3>
-              <div class="subheading mb-3">Robert Sapolsky</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/18122.The_Amber_Spyglass" target="_blank">The Amber Spyglass</a></h3>
-              <div class="subheading mb-3">Phillip Pullman</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/41637836-the-subtle-knife" target="_blank">The Subtle Knife</a></h3>
-              <div class="subheading mb-3">Phillip Pullman</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/70947.Northern_Lights" target="_blank">The Northern Lights</a></h3>
-              <div class="subheading mb-3">Phillip Pullman</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/10847.Under_the_Banner_of_Heaven" target="_blank">Under the Banner of Heaven</a></h3>
-              <div class="subheading mb-3">Jon Krakauer</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/12067.Good_Omens" target="_blank">Good Omens</a></h3>
-              <div class="subheading mb-3">Terry Pratchett and Neil Gaiman</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/33932359-global-discontents" target="_blank">Global Discontents</a></h3>
-              <div class="subheading mb-3">Noam Chomsky</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/194805.Understanding_Power" target="_blank" class="text-success">Understanding Power</a></h3>
-              <div class="subheading mb-3">Noam Chomsky</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/37976541-bad-blood" target="_blank">Bad Blood</a></h3>
-              <div class="subheading mb-3">John Carreyrou</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/25899336-when-breath-becomes-air" target="_blank">When Breath Becomes Air</a></h3>
-              <div class="subheading mb-3">Paul Kalanithi</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/36490332-talking-to-my-daughter-about-the-economy" target="_blank">Talking to my Daughter About the Economy</a></h3>
-              <div class="subheading mb-3">Yanis Varoufakis</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/33606119-why-i-m-no-longer-talking-to-white-people-about-race" target="_blank">Why I'm No Longer Talking to White People About Race</a></h3>
-              <div class="subheading mb-3">Reni Eddo-Lodge</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/38820046-21-lessons-for-the-21st-century" target="_blank">21 Lessons for the 21st Century</a></h3>
-              <div class="subheading mb-3">Yuval Noah Harari</div>
-
-
-              <h2 class="mb-5">2018</h2>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/34673467-adults-in-the-room" target="_blank">Adults in the Room</a></h3>
-              <div class="subheading mb-3">Yanis Varoufakis</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/35235302-this-is-going-to-hurt" target="_blank">This is Going to Hurt</a></h3>
-              <div class="subheading mb-3">Adam Kay</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/11828537-cat-s-cradle" target="_blank">Cat's Cradle</a></h3>
-              <div class="subheading mb-3">Kurt Vonnegut</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/4980.Breakfast_of_Champions" target="_blank">Breakfast of Champions</a></h3>
-              <div class="subheading mb-3">Kurt Vonnegut</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/4981.Slaughterhouse_Five" target="_blank" class="text-success">Slaughterhouse-Five</a></h3>
-              <div class="subheading mb-3">Kurt Vonnegut</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/28676.American_Psycho" target="_blank">American Psycho</a></h3>
-              <div class="subheading mb-3">Bret Easton Ellis</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/23692271-sapiens" target="_blank">Sapiens</a></h3>
-              <div class="subheading mb-3">Yuval Noah Harari</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/35167685-surely-you-re-joking-mr-feynman" target="_blank" class="text-success">Surely You're Joking Mr. Feynman!</a></h3>
-              <div class="subheading mb-3">Richard Feynman</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/36402034-do-androids-dream-of-electric-sheep" target="_blank">Do Androids Dream of Electric Sheep</a></h3>
-              <div class="subheading mb-3">Philip K. Dick</div>
-
-              <h2 class="mb-5">2017</h2>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/157993.The_Little_Prince" target="_blank" class="text-success">The Little Prince</a></h3>
-              <div class="subheading mb-3">Antoine de Saint-Exupéry</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/216363.The_Man_in_the_High_Castle" target="_blank">The Man in the High Castle</a></h3>
-              <div class="subheading mb-3">Phillip K. Dick</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/216363.The_Man_in_the_High_Castle" target="_blank">The Man in the High Castle</a></h3>
-              <div class="subheading mb-3">Phillip K. Dick</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/4381.Fahrenheit_451" target="_blank">Fahrenheit 451</a></h3>
-              <div class="subheading mb-3">Ray Bradbury</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/7745.Fear_and_Loathing_in_Las_Vegas" target="_blank">Fear and Loating in Las Vegas</a></h3>
-              <div class="subheading mb-3">Hunter S. Thompson</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/70535.2001" target="_blank">2001: A Space Odyssey</a></h3>
-              <div class="subheading mb-3">Arthur C. Clarke</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/1202.Freakonomics" target="_blank">Feakonomics</a></h3>
-              <div class="subheading mb-3">Steven D. Levitt and Stephen J. Dubner</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/7613.Animal_Farm" target="_blank">Animal Farm</a></h3>
-              <div class="subheading mb-3">George Orwell</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/7624.Lord_of_the_Flies" target="_blank">Lord of the Flies</a></h3>
-              <div class="subheading mb-3">William Golding</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/234225.Dune" target="_blank">Dune</a></h3>
-              <div class="subheading mb-3">Frank Herbert</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/8696.Last_Chance_to_See" target="_blank" class="text-success">Last Chance to See</a></h3>
-              <div class="subheading mb-3">Douglas Adams</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/4671.The_Great_Gatsby" target="_blank">The Great Gatsby</a></h3>
-              <div class="subheading mb-3">F. Scott Fitzgerald</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/6604712-eating-animals" target="_blank">Eating Animals</a></h3>
-              <div class="subheading mb-3">Jonathan Safran Foer</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/61535.The_Selfish_Gene" target="_blank" class="text-success">The Selfish Gene</a></h3>
-              <div class="subheading mb-3">Richard Dawkins</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/46756.Oryx_and_Crake" target="_blank">Oryx and Crake</a></h3>
-              <div class="subheading mb-3">Margaret Atwood</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/38447.The_Handmaid_s_Tale" target="_blank" class="text-success">The Handmaid's Tale</a></h3>
-              <div class="subheading mb-3">Margaret Atwood</div>
-
-
-              <h2 class="mb-5">2016</h2>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/76171.We" target="_blank">We</a></h3>
-              <div class="subheading mb-3">Yevgeny Zamyatin</div>
-
-              <h3 class="mb-0"><a href="hhttps://www.goodreads.com/book/show/5129.Brave_New_World" target="_blank">Brave New World</a></h3>
-              <div class="subheading mb-3">Aldous Huxley</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/5470.1984" target="_blank">1984</a></h3>
-              <div class="subheading mb-3">George Orwell</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/569429.Mostly_Harmless" target="_blank">Mostly Harmless</a></h3>
-              <div class="subheading mb-3">Douglas Adams</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/6091075-so-long-and-thanks-for-all-the-fish" target="_blank">So Long, and Thanks for All the Fish</a></h3>
-              <div class="subheading mb-3">Douglas Adams</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/8694.Life_the_Universe_and_Everything" target="_blank">Life, the Universe and Everything</a></h3>
-              <div class="subheading mb-3">Douglas Adams</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/8695.The_Restaurant_at_the_End_of_the_Universe" target="_blank">The Restaurant at the End of the Universe</a></h3>
-              <div class="subheading mb-3">Douglas Adams</div>
-
-              <h3 class="mb-0"><a href="https://www.goodreads.com/book/show/386162.The_Hitchhiker_s_Guide_to_the_Galaxy" target="_blank" class="text-success">The Hitchhiker's Guide to the Galaxy</a></h3>
-              <div class="subheading mb-3">Douglas Adams</div>
-
-
-
-
-
-
-
-
-
-
-              
-
-
-
-
-	          
+            <!-- Get bookshelf content-->
+            <script src="js/bookshelf.js"></script>
 	</div>
 </body>
 </html>

--- a/js/bookshelf.js
+++ b/js/bookshelf.js
@@ -1,0 +1,46 @@
+$(function(){
+
+	let sheet_id = '1FlNKr2dJU6UsCW9R1kTttYcUNqt6M5mVW9bSVNL2q0g';
+	var sheetUrl = `http://spreadsheets.google.com/feeds/cells/${sheet_id}/1/public/full?alt=json`;
+
+	$.getJSON(sheetUrl, function(data){
+
+		var entries = data.feed.entry;
+		var parsed_entries = [];
+
+		var n_col = 5
+		var n_row = (entries.length / n_col) - 1
+
+		for (var i = 1; i <= n_row; i += 1){
+		    var j = n_col*i
+		    var entry = {
+		    	'title': entries[j].content.$t,
+		    	'author': entries[j+1].content.$t,
+		    	'completed_date': entries[j+2].content.$t,
+		    	'url': entries[j+3].content.$t,
+		    	'favourite': entries[j+4].content.$t
+		    }
+		    parsed_entries.push(entry);
+		  }
+
+		$.each(parsed_entries.reverse(), function(index, value) {
+			var heading_link = $('<a/>', {
+				'text': value["title"],
+				'href': value["url"]
+			})
+			if (value["favourite"] == 1){
+				heading_link.addClass('text-success')
+			}
+			var subheading = $('<div>', {
+				'class':'subheading mb-3',
+				'text': value["author"]
+			})
+
+			$( "#bookshelfContent" ).append([
+				$('<h3/>', {'class': "mb-0"}).append([heading_link]),
+				subheading
+			])
+		});
+	});
+
+});


### PR DESCRIPTION
Migrate bookshelf to backend hosted on published google sheets table which I can modify without having to change website source. 
- Removes the source for books on bookshelf.
- Adds script to get data from public endpoint, parse the JSON and create elements for each book.